### PR TITLE
Upgrade to solana 2.2.6

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ members = [
 ]
 
 [workspace.metadata.cli]
-solana = "2.2.0"
+solana = "2.2.6"
 
 [workspace.metadata.toolchains]
 format = "1.84.1"

--- a/README.md
+++ b/README.md
@@ -8,7 +8,6 @@
   A simple benchmark of SVM entrypoints.
 </p>
 
-
 ## Overview
 
 The purpose of `eisodos` is to offer a simple benchmark of different program entrypoint implementations. An entrypoint is used to parse the [SBF input](https://solana.com/docs/programs/faq#input-parameter-serialization) for a program, providing the information of an instruction input in a "friendly" way. The SBF loader passes the input parameters as a byte array and the entrypoint then transforms the input into separate typed entities &mdash; `program id`, `accounts` array and `instruction data`.
@@ -17,36 +16,37 @@ The purpose of `eisodos` is to offer a simple benchmark of different program ent
 
 Entrypoint implementation currently included in the benchmark:
 
-* [`pinocchio`](https://github.com/anza-xyz/pinocchio)
-* [`solana-nostd-entrypoint`](https://github.com/cavemanloverboy/solana-nostd-entrypoint)
-* [`solana-program`](https://github.com/anza-xyz/agave/tree/master/sdk/program)
+- [`pinocchio`](https://github.com/anza-xyz/pinocchio)
+- [`solana-nostd-entrypoint`](https://github.com/cavemanloverboy/solana-nostd-entrypoint)
+- [`solana-program`](https://github.com/anza-xyz/agave/tree/master/sdk/program)
 
-| Benchmark              | `pinocchio`    | `solana-nostd-entrypoint`    | `solana-program`    |
-|------------------------|----------------|------------------------------|---------------------|
-| *Entrypoint*                                                                                 |
-| Ping                   | 🟩 **14**      | 🟩 **15**                     | 🟧 42 (+28)         |
-| Log                    | 🟩 **119**     | 🟩 **120**                    | 🟧 147 (+28)        |
-| Account (1)            | 🟩 **42**      | 🟩 **42**                     | 🟥 242 (+200)       |
-| Account (3)            | 🟩 **70**      | 🟩 72 (+2)                    | 🟥 560 (+490)       |
-| Account (5)            | 🟩 **98**      | 🟩 102 (+4)                   | 🟥 878 (+780)       |
-| Account (10)           | 🟩 **168**     | 🟩 177 (+9)                   | 🟥 1,673 (+1,505)   | 
-| Account (20)           | 🟩 **308**     | 🟨 327 (+19)                  | 🟥 3,264 (+2,955)   |
-| Account (32)           | 🟩 **476**     | 🟨 507 (+31)                  | 🟥 5,171 (+4,695)   |
-| Account (64)           | 🟩 **924**     | 🟨 988 (+64)                  | 🟥 10,259 (+9,335)  |
-| *CPI*                                                                                        |
-| CreateAccount          | 🟩 **1,443**   | 🟨 1,488 (+45)                | 🟥 2,867 (+1,424)   |
-| Transfer               | 🟩 **1,433**   | 🟨 1,480 (+47)                | 🟥 2,415 (+982)     |
+| Benchmark     | `pinocchio`  | `solana-nostd-entrypoint` | `solana-program`  |
+| ------------- | ------------ | ------------------------- | ----------------- |
+| _Entrypoint_  |
+| Ping          | 🟩 **14**    | 🟩 **14**                 | 🟧 41 (+27)       |
+| Log           | 🟩 **119**   | 🟩 **119**                | 🟧 146 (+27)      |
+| Account (1)   | 🟩 **38**    | 🟩 39 (+1)                | 🟥 235 (+196)     |
+| Account (3)   | 🟩 **66**    | 🟩 69 (+3)                | 🟥 541 (+475)     |
+| Account (5)   | 🟩 **94**    | 🟩 99 (+5)                | 🟥 847 (+753)     |
+| Account (10)  | 🟩 **164**   | 🟩 174 (+10)              | 🟥 1,612 (+1,448) |
+| Account (20)  | 🟩 **304**   | 🟨 324 (+20)              | 🟥 3,142 (+2,838) |
+| Account (32)  | 🟩 **472**   | 🟨 504 (+32)              | 🟥 4,978 (+4,506) |
+| Account (64)  | 🟩 **920**   | 🟨 985 (+65)              | 🟥 9,874 (+8,954) |
+| _CPI_         |
+| CreateAccount | 🟩 **1,449** | 🟨 1,494 (+45)            | 🟥 2,786 (+1,337) |
+| Transfer      | 🟩 **1,439** | 🟨 1,487 (+48)            | 🟥 2,379 (+940)   |
 
 > [!IMPORTANT]
 > Values correspond to compute units (CUs) consumed by the entrypoint. The delta in relation to the lowest consumption is shown in brackets.
 >
-> Solana CLI `v2.2.0` was used in the bench tests.
+> Solana CLI `v2.2.6` was used in the bench tests.
 
 ## Benchmark
 
-The benchmark uses a simple program with multiple instructions to measure the compute units (CUs) consumed by the entrypoint. Note that the intention is not to write the most efficient program, instead to reflect an "average" program implemenation. The aim is to use the exactly same program implementation, replacing the entrypoint to determine the impact on the CUs consumed.
+The benchmark uses a simple program with multiple instructions to measure the compute units (CUs) consumed by the entrypoint. Note that the intention is not to write the most efficient program, instead to reflect an "average" program implementation. The aim is to use the exactly same program implementation, replacing the entrypoint to determine the impact on the CUs consumed.
 
 The program used has the following instructions:
+
 ```rust
 pub enum Instruction {
     Ping,
@@ -83,13 +83,13 @@ This instruction receives 3 accounts (`from`, `to` and `system_program`) and per
 
 The program is structure in 4 different source files:
 
-* `entrypoint.rs`: includes the entrypoint definition and "dispatches" the instruction to the corresponding processor.
+- `entrypoint.rs`: includes the entrypoint definition and "dispatches" the instruction to the corresponding processor.
 
-* `instruction.rs`: defines the instructions available on the program and the parsing logic for the input instruction data.
+- `instruction.rs`: defines the instructions available on the program and the parsing logic for the input instruction data.
 
-* `lib.rs`: defines the modules of the program and the program ID.
+- `lib.rs`: defines the modules of the program and the program ID.
 
-* `processor.rs`: includes the processor for each instruction.
+- `processor.rs`: includes the processor for each instruction.
 
 The implementation across all different entrypoint programs is as similar as possible. In most cases, the only differences are on the types import, since each entrypoint defines their own `AccountInfo` and/or `Pubkey` types.
 
@@ -119,10 +119,10 @@ The `ENTRYPOINT_NAME` will be one of `pinocchio`, `solana_nostd_entrypoint` or `
 
 The results are written to `./target/benches/compute_units.md`. Each execution is described by 3 columns:
 
-* `Name`: name of the benchmark; this will specify the name of the instruction and the parameters used.
+- `Name`: name of the benchmark; this will specify the name of the instruction and the parameters used.
 
-* `CUs`: number of compute units consumed by the execution.
+- `CUs`: number of compute units consumed by the execution.
 
-* `Delta`: the difference in compute units between latest benchmark and the previous; this will provide a quick way to assess the differences between entrypoints.
+- `Delta`: the difference in compute units between latest benchmark and the previous; this will provide a quick way to assess the differences between entrypoints.
 
 The results of an execution are compared to the previous one (if there is one), with delta differences shown after a `+` and `-` symbol.

--- a/scripts/program/build.mjs
+++ b/scripts/program/build.mjs
@@ -1,17 +1,12 @@
 #!/usr/bin/env zx
 import 'zx/globals';
 import {
-  cliArguments,
   getProgramFolders,
   workingDirectory,
 } from '../utils.mjs';
 
 // Save external programs binaries to the output directory.
 import './dump.mjs';
-
-// Configure additional arguments here, e.g.:
-// ['--arg1', '--arg2', ...cliArguments()]
-const buildArgs = cliArguments();
 
 // Build the programs.
 for (const folder of getProgramFolders()) {


### PR DESCRIPTION
Rerun benchmarks with cargo-build-sbf v2.26 and update values.

Apologies for the markdown reformatting, could you please share your formatter's settings so that i can sync with it? Thank you.